### PR TITLE
Add checklist item regarding default margins for headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,30 @@ following the lesson videos.
 Additionally:
 1. Add a favicon
 2. Don’t forget to add a title for the whole web page (it could be the name of your landing)
-3. Logos in header and footer should be links to home page 
+3. Logos in header and footer should be links to home page
 4. Change text color on hover for phone, email and address
 5. When you click on ‘CALL TO ORDER’, make sure that there is no 404 error, make it a real link to activate your phone on your laptop/phone
 6. In the “Miami best” block, make sure that the “Real estate here” link does not lead to a 404 error, but to a location in Google Maps
-7. Pictures in Gallery should increase on hover 
-9. Gallery links should open google maps in a new tab `target="_blank"`
-10. Photos in the Testimonials section should also increase on hover
-11. Make sure everything looks neat on mobile and without horizontal scrolling
-12. The speed of animations is the same throughout the landing page (for example, increasing when hovering or moving blocks when scrolling)
-13. Placeholders in the forms suggest what to enter, and if there is a validation of the form, then it is clear in what format to enter the data
-14. Add a smooth scroll for the whole page
-15. Fix menu for small screens (if there is not enough space for all the menu items)
+7. Pictures in Gallery should increase on hover
+8. Gallery links should open google maps in a new tab `target="_blank"`
+9. Photos in the Testimonials section should also increase on hover
+10. Make sure everything looks neat on mobile and without horizontal scrolling
+11. The speed of animations is the same throughout the landing page (for example, increasing when hovering or moving blocks when scrolling)
+12. Placeholders in the forms suggest what to enter, and if there is a validation of the form, then it is clear in what format to enter the data
+13. Add a smooth scroll for the whole page
+14. Fix menu for small screens (if there is not enough space for all the menu items)
     ```css
     .menu {
       /* Move these rules from .menu__content */
       box-sizing: border-box;
       height: 100vh;
       padding: 24px 0;
-      
+
       background-color: #0075ff;
-      
+
       /* Add this rule to add scroll when there is not enough space */
       overflow-y: auto;
-      
+
       ...
     ```
 15. To disable page scrolling under the menu add the next code
@@ -46,3 +46,4 @@ Additionally:
       }
     });
     ```
+16. Remember to reset default margins for headings (h1, h2, h3, etc.). Make sure that <h1> is positioned exactly 80px from the bottom of the header.

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Additionally:
       }
     });
     ```
-16. Remember to reset default margins for headings (h1, h2, h3, etc.). Make sure that <h1> is positioned exactly 80px from the bottom of the header.
+16. Remember to reset default margins for headings (h1, h2, h3, etc.). Make sure that `<h1>` is positioned exactly 80px from the bottom of the header.

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Additionally:
       }
     });
     ```
-16. Remember to reset default margins for headings (h1, h2, h3, etc.). Make sure that `<h1>` is positioned exactly 80px from the bottom of the header.
+16. Remember to reset default margins for headings (h1, h2, h3, etc.). Make sure that ```<h1>``` is positioned exactly 80px from the bottom of the header.


### PR DESCRIPTION
New checklist item was added:
16. Remember to reset default margins for headings (h1, h2, h3, etc.). Make sure that ```<h1>``` is positioned exactly 80px from the bottom of the header.